### PR TITLE
Hide impact docs.

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -33,7 +33,7 @@ func init() {
 	docs.AddEndpoint("region", &regionDoc)
 	docs.AddEndpoint("felt", &feltDoc)
 	docs.AddEndpoint("news", &newsDoc)
-	docs.AddEndpoint("impact", &impactDoc)
+	// docs.AddEndpoint("impact", &impactDoc)
 }
 
 var exHost = "http://localhost:" + config.WebServer.Port


### PR DESCRIPTION
This just hides the docs - so we are not advertising the service while we get it to prod and stable.

The service still works.