### PR TITLE
Simplify reported impact services

### DIFF
--- a/ddl/impact-create.ddl
+++ b/ddl/impact-create.ddl
@@ -11,12 +11,13 @@ CREATE TABLE impact.intensity_reported (
 	comment varchar(140) NOT NULL,
 	geohash5 varchar(5) NOT NULL,
 	geohash6 varchar(6) NOT NULL,
-	geohash7 varchar(7) NOT NULL,
 	location GEOGRAPHY(POINT, 4326) NOT NULL,
 	UNIQUE (source, time)
 );
 
 CREATE INDEX ON impact.intensity_reported (time);
+CREATE INDEX ON impact.intensity_reported (geohash5);
+CREATE INDEX ON impact.intensity_reported (geohash6);
 
 -- impact.intensity_measured is for measured shaking intensity.
 CREATE TABLE impact.intensity_measured (

--- a/ddl/impact-functions.ddl
+++ b/ddl/impact-functions.ddl
@@ -16,8 +16,8 @@ RETURN;
 END IF;
 
 BEGIN
-INSERT INTO impact.intensity_reported(source, time, mmi, comment, geohash5, geohash6, geohash7, location) 
-VALUES (source_n, time_n, mmi_n, comment_n, st_geohash(loc, 5), st_geohash(loc, 6), st_geohash(loc, 7), loc);
+INSERT INTO impact.intensity_reported(source, time, mmi, comment, geohash5, geohash6, location) 
+VALUES (source_n, time_n, mmi_n, comment_n, st_geohash(loc, 5), st_geohash(loc, 6), loc);
 RETURN;
 EXCEPTION WHEN unique_violation THEN
 --  Loop once more to see if a different insert happened after the update but before our insert.

--- a/intensity.go
+++ b/intensity.go
@@ -1,27 +1,25 @@
 package main
 
 import (
+	"database/sql"
 	"github.com/GeoNet/web"
 	"github.com/GeoNet/web/api/apidoc"
 	"html/template"
 	"net/http"
 	"regexp"
+	"time"
 )
 
 var impactDoc = apidoc.Endpoint{Title: "Impact",
 	Description: `Look up impact information`,
 	Queries: []*apidoc.Query{
-		// new(intensityReportedQuery).Doc(),  // hide reported docs for now.  Not collecting any yet.
-		// new(intensityReportedLatestQuery).Doc(),
+		new(intensityReportedQuery).Doc(),
+		new(intensityReportedLatestQuery).Doc(),
 		new(intensityMeasuredLatestQuery).Doc(),
 	},
 }
 
-// Not the most accurate ISO8601 match in the world but it will do.
-var startRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00Z$`)
-var bboxRe = regexp.MustCompile(`^-*\d+,-*\d+,-*\d+,-*\d+$`)
-var windowRe = regexp.MustCompile(`^(15)$`)
-var zoomRe = regexp.MustCompile(`^(5|6|7)$`)
+var zoomRe = regexp.MustCompile(`^(5|6)$`)
 
 var intensityMeasuredLatestQueryD = &apidoc.Query{
 	Accept:      web.V1GeoJSON,
@@ -88,14 +86,12 @@ var intensityReportedLatestQueryD = &apidoc.Query{
 	Accept:      web.V1GeoJSON,
 	Title:       "Reported Intensity - Latest",
 	Description: "Retrieve reported intensity information in the last sixty minutes.",
-	Example:     "/intensity?type=reported&bbox=165,-34,179,-47&zoom=5",
+	Example:     "/intensity?type=reported&zoom=5",
 	ExampleHost: exHost,
-	URI:         "/intensity?type=reported&bbox=(bbox)&zoom=(int)",
+	URI:         "/intensity?type=reported&zoom=(int)",
 	Params: map[string]template.HTML{
-		"bbox": `A spatial bounding box for the query describing the upper left and lower right longitude and latitude corners.  Integer values only.
-				e.g., <code>165,-34,179,-47</code> would include mainland New Zealand.`,
 		"zoom": `The zoom level to aggregate values at.  This controls the size of the area that values are aggregated at.  The point returned
-				will be the center of each area.  Allowed values are one of <code>5, 6, 7</code>.`,
+				will be the center of each area.  Allowed values are one of <code>5, 6</code>.`,
 	},
 	Props: map[string]template.HTML{
 		"max_mmi": `the maximum <a href="http://info.geonet.org.nz/x/w4IO">Modified Mercalli Intensity (MMI)</a> 
@@ -108,18 +104,15 @@ var intensityReportedLatestQueryD = &apidoc.Query{
 }
 
 type intensityReportedLatestQuery struct {
-	bbox, zoom string
+	zoom string
 }
 
 func (q *intensityReportedLatestQuery) Validate(w http.ResponseWriter, r *http.Request) bool {
 	switch {
-	case len(r.URL.Query()) != 3:
+	case len(r.URL.Query()) != 2:
 		web.BadRequest(w, r, "incorrect number of query parameters.")
 		return false
-	case !web.ParamsExist(w, r, "type", "bbox", "zoom"):
-		return false
-	case !bboxRe.MatchString(r.URL.Query().Get("bbox")):
-		web.BadRequest(w, r, "Invalid bbox")
+	case !web.ParamsExist(w, r, "type", "zoom"):
 		return false
 	case !zoomRe.MatchString(r.URL.Query().Get("zoom")):
 		web.BadRequest(w, r, "Invalid zoom")
@@ -129,7 +122,6 @@ func (q *intensityReportedLatestQuery) Validate(w http.ResponseWriter, r *http.R
 		return false
 	}
 
-	q.bbox = r.URL.Query().Get("bbox")
 	q.zoom = r.URL.Query().Get("zoom")
 
 	return true
@@ -155,7 +147,7 @@ func (q *intensityReportedLatestQuery) Handle(w http.ResponseWriter, r *http.Req
 						count(mmi) as count 
 						FROM impact.intensity_reported  
 						WHERE time >= (now() - interval '60 minutes')
-						AND location && ST_MakeEnvelope(` + q.bbox + `, 4326) group by (geohash` + q.zoom + `)) as s
+						group by (geohash` + q.zoom + `)) as s
 					) As f )  as fc`).Scan(&d)
 	if err != nil {
 		web.ServiceUnavailable(w, r, err)
@@ -175,18 +167,14 @@ func (q *intensityReportedLatestQuery) Doc() *apidoc.Query {
 var intensityReportedQueryD = &apidoc.Query{
 	Accept:      web.V1GeoJSON,
 	Title:       "Reported Intensity",
-	Description: "Retrieve reported intensity information in a time window.",
-	Example:     "/intensity?type=reported&bbox=165,-34,179,-47&start=2014-01-08T12:00:00Z&window=15&zoom=5",
+	Description: "Retrieve reported intensity information in a 15 minute time window after an event.",
+	Example:     "/intensity?type=reported&zoom=5&publicID=2013p407387",
 	ExampleHost: exHost,
-	URI:         "/intensity?type=reported&bbox=(bbox)&zoom=(int)&start=(ISO8601 date time)&window=(int)",
+	URI:         "/intensity?type=reported&zoom=(int)&publicID=(publicID)",
 	Params: map[string]template.HTML{
-		"start": `the date time in ISO8601 format for the start of the time window for the request. Only queries to the nearest minute
-						are supported so the parameter must always end in <code>:00Z</code> e.g., <code>2014-01-08T12:00:00Z</code>`,
-		"window": `The length of time window in minutes for the request.  Currently only the value <code>15</code> is supported.`,
-		"bbox": `A spatial bounding box for the query describing the upper left and lower right longitude and latitude corners.  Integer values only.
-						e.g., <code>165,-34,179,-47</code> would include mainland New Zealand.`,
 		"zoom": `The zoom level to aggregate values at.  This controls the size of the area that values are aggregated at.  The point returned
-						will be the center of each area.  Allowed values are one of <code>5, 6, 7</code>.`,
+						will be the center of each area.  Allowed values are one of <code>5, 6</code>.`,
+		"publicID": `a valid quake ID e.g., <code>2014p715167</code>`,
 	},
 	Props: map[string]template.HTML{
 		"max_mmi": `the maximum <a href="http://info.geonet.org.nz/x/w4IO">Modified Mercalli Intensity (MMI)</a> 
@@ -199,64 +187,69 @@ var intensityReportedQueryD = &apidoc.Query{
 }
 
 type intensityReportedQuery struct {
-	bbox, zoom, start, window string
+	zoom       string
+	originTime time.Time
 }
 
 func (q *intensityReportedQuery) Validate(w http.ResponseWriter, r *http.Request) bool {
 	switch {
-	case len(r.URL.Query()) != 5:
+	case len(r.URL.Query()) != 3:
 		web.BadRequest(w, r, "incorrect number of query parameters.")
 		return false
-	case !web.ParamsExist(w, r, "type", "bbox", "zoom", "window", "start"):
-		return false
-	case !bboxRe.MatchString(r.URL.Query().Get("bbox")):
-		web.BadRequest(w, r, "Invalid bbox")
+	case !web.ParamsExist(w, r, "type", "zoom", "publicID"):
 		return false
 	case !zoomRe.MatchString(r.URL.Query().Get("zoom")):
 		web.BadRequest(w, r, "Invalid zoom")
 		return false
-	case !windowRe.MatchString(r.URL.Query().Get("window")):
-		web.BadRequest(w, r, "Invalid window")
-		return false
-	case !startRe.MatchString(r.URL.Query().Get("start")):
-		web.BadRequest(w, r, "Invalid start")
+	case !publicIDRe.MatchString(r.URL.Query().Get("publicID")):
+		web.BadRequest(w, r, "Invalid publicID")
 		return false
 	case r.URL.Query().Get("type") != "reported":
 		web.BadRequest(w, r, "Invalid type")
 		return false
 	}
 
-	q.bbox = r.URL.Query().Get("bbox")
 	q.zoom = r.URL.Query().Get("zoom")
-	q.window = r.URL.Query().Get("window")
-	q.start = r.URL.Query().Get("start")
+
+	// Check that the publicid exists in the DB.
+	// If it does we keep the origintime - we need it later on.
+	err := db.QueryRow("select origintime FROM qrt.quake_materialized where publicid = $1", r.URL.Query().Get("publicID")).Scan(&q.originTime)
+	if err == sql.ErrNoRows {
+		web.NotFound(w, r, "invalid publicID: "+r.URL.Query().Get("publicID"))
+		return false
+	}
+	if err != nil {
+		web.ServiceUnavailable(w, r, err)
+		return false
+	}
 
 	return true
 }
 
 func (q *intensityReportedQuery) Handle(w http.ResponseWriter, r *http.Request) {
+	query := `SELECT row_to_json(fc)
+				FROM ( SELECT 'FeatureCollection' as type, COALESCE(array_to_json(array_agg(f)), '[]') as features
+					FROM (SELECT 'Feature' as type,
+						ST_AsGeoJSON(s.location)::json as geometry,
+						row_to_json(( select l from 
+							( 
+							select max_mmi,
+							min_mmi,
+							count
+							) as l )) 
+							as properties from (select st_pointfromgeohash(geohash` + q.zoom + `) as location, 
+							min(mmi) as min_mmi, 
+							max(mmi) as max_mmi, 
+							count(mmi) as count 
+							FROM impact.intensity_reported 
+							WHERE time >= $1
+							AND time <= $2
+							group by (geohash` + q.zoom + `)) as s
+			) As f )  as fc`
+
 	var d string
 
-	err := db.QueryRow(
-		`SELECT row_to_json(fc)
-								FROM ( SELECT 'FeatureCollection' as type, COALESCE(array_to_json(array_agg(f)), '[]') as features
-									FROM (SELECT 'Feature' as type,
-										ST_AsGeoJSON(s.location)::json as geometry,
-										row_to_json(( select l from 
-											( 
-												select max_mmi,
-												min_mmi,
-												count
-												) as l )) 
-							as properties from (select st_pointfromgeohash(geohash` + q.zoom + `) as location, 
-								min(mmi) as min_mmi, 
-								max(mmi) as max_mmi, 
-								count(mmi) as count 
-								FROM impact.intensity_reported 
-								WHERE time >= timestamp with time zone '` + q.start + `'
-								AND time <= (timestamp with time zone '` + q.start + `' + interval '` + q.window + ` minutes')
-								AND location && ST_MakeEnvelope(` + q.bbox + `, 4326) group by (geohash` + q.zoom + `)) as s
-							) As f )  as fc`).Scan(&d)
+	err := db.QueryRow(query, q.originTime.Add(time.Duration(-1*time.Minute)), q.originTime.Add(time.Duration(15*time.Minute))).Scan(&d)
 	if err != nil {
 		web.ServiceUnavailable(w, r, err)
 		return

--- a/routes.go
+++ b/routes.go
@@ -67,12 +67,12 @@ func router(w http.ResponseWriter, r *http.Request) {
 			case r.URL.Query().Get("type") == "measured":
 				q := &intensityMeasuredLatestQuery{}
 				api.Serve(q, w, r)
-			// /intensity?type=reported&bbox=165,-34,179,-47&zoom=5
-			case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("start") == "":
+			// /intensity?type=reported&zoom=5
+			case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") == "":
 				q := &intensityReportedLatestQuery{}
 				api.Serve(q, w, r)
-			// /intensity?type=reported&bbox=165,-34,179,-47&start=2014-01-08T12:00:00Z&window=15&zoom=5
-			case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("start") != "":
+			// /intensity?type=reported&zoom=5&publicID=2012p23456
+			case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") != "":
 				q := &intensityReportedQuery{}
 				api.Serve(q, w, r)
 			default:

--- a/routes_test.go
+++ b/routes_test.go
@@ -68,8 +68,8 @@ func TestRoutes(t *testing.T) {
 	r.Add("/quake?regionID=fiordland&intensity=unnoticeable&number=3&quality=best,caution,good")
 	r.Add("/quake?regionID=otagosouthland&intensity=unnoticeable&number=3&quality=best,caution,good")
 	r.Add("/intensity?type=measured")
-	r.Add("/intensity?type=reported&bbox=165,-34,179,-47&zoom=5")
-	r.Add("/intensity?type=reported&bbox=165,-34,179,-47&start=2014-01-08T12:00:00Z&window=15&zoom=5")
+	r.Add("/intensity?type=reported&zoom=5")
+	r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
 
 	r.Test(ts, t)
 
@@ -186,8 +186,8 @@ func TestGeoJSON(t *testing.T) {
 	r.Add("/region?type=quake")
 	r.Add("/felt/report?publicID=2013p407387")
 	r.Add("/intensity?type=measured")
-	r.Add("/intensity?type=reported&bbox=165,-34,179,-47&zoom=5")
-	r.Add("/intensity?type=reported&bbox=165,-34,179,-47&start=2014-01-08T12:00:00Z&window=15&zoom=5")
+	r.Add("/intensity?type=reported&zoom=5")
+	r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
 
 	r.GeoJSON(ts, t)
 }


### PR DESCRIPTION
Only use geohash 5 and 6
Drop the bbox
Allow search by publicID

Resolves #80 

If you want to review the api-docs in a browser you will need to uncomment routes.go L36

If this looks ok to you I will need to change the DB schema on prod.  You can merge anytime though.

Thanks,
Geoff
