### PR TITLE
Optional versioning

### DIFF
--- a/intensity.go
+++ b/intensity.go
@@ -13,8 +13,8 @@ import (
 var impactDoc = apidoc.Endpoint{Title: "Impact",
 	Description: `Look up impact information`,
 	Queries: []*apidoc.Query{
-		intensityReportedD,
-		intensityReportedLatestD,
+		// intensityReportedD,
+		// intensityReportedLatestD,
 		intensityMeasuredLatestD,
 	},
 }

--- a/news.go
+++ b/news.go
@@ -115,7 +115,6 @@ func news(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Surrogate-Control", web.MaxAge300)
-	w.Header().Set("Content-Type", web.V1JSON)
 
 	web.Ok(w, r, &j)
 }

--- a/routes.go
+++ b/routes.go
@@ -23,7 +23,7 @@ func init() {
 	docs.AddEndpoint("region", &regionDoc)
 	docs.AddEndpoint("felt", &feltDoc)
 	docs.AddEndpoint("news", &newsDoc)
-	// docs.AddEndpoint("impact", &impactDoc)
+	docs.AddEndpoint("impact", &impactDoc)
 }
 
 var exHost = "http://localhost:" + config.WebServer.Port
@@ -56,10 +56,10 @@ func router(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Query().Get("type") == "measured":
 			intensityMeasuredLatest(w, r)
-		case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") == "":
-			intensityReportedLatest(w, r)
-		case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") != "":
-			intensityReported(w, r)
+		// case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") == "":
+		// 	intensityReportedLatest(w, r)
+		// case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") != "":
+		// 	intensityReported(w, r)
 		default:
 			web.BadRequest(w, r, "Can't find a route for this request. Please refer to /api-docs")
 		}

--- a/routes.go
+++ b/routes.go
@@ -14,8 +14,8 @@ var docs = apidoc.Docs{
 	Description: `<p>The data provided here is used for the GeoNet web site and other similar services. 
 			If you are looking for data for research or other purposes then please check the 
 			<a href="http://info.geonet.org.nz/x/DYAO">full range of data</a> available from GeoNet. </p>`,
-	// RepoURL: `https://github.com/GeoNet/geonet-rest`,
-	StrictVersioning: true,
+	RepoURL:          `https://github.com/GeoNet/geonet-rest`,
+	StrictVersioning: false,
 }
 
 func init() {
@@ -29,50 +29,52 @@ func init() {
 var exHost = "http://localhost:" + config.WebServer.Port
 
 func router(w http.ResponseWriter, r *http.Request) {
+	// requests that don't have a specific version header are routed to the latest version.
+	var latest bool
+	accept := r.Header.Get("Accept")
+	switch accept {
+	case web.V1GeoJSON, web.V1JSON:
+	default:
+		latest = true
+	}
+
 	switch {
-	case r.Header.Get("Accept") == web.V1GeoJSON:
+	case strings.HasPrefix(r.URL.Path, "/quake") && (accept == web.V1GeoJSON || latest):
 		w.Header().Set("Content-Type", web.V1GeoJSON)
 		switch {
-		case strings.HasPrefix(r.URL.Path, "/quake"):
-			switch {
-			case r.URL.Query().Get("intensity") != "":
-				quakes(w, r)
-			case r.URL.Query().Get("regionIntensity") != "":
-				quakesRegion(w, r)
-			case strings.HasPrefix(r.URL.Path, "/quake/"):
-				quake(w, r)
-			default:
-				web.BadRequest(w, r, "service not found.")
-			}
-		case r.URL.Path == "/intensity":
-			switch {
-			case r.URL.Query().Get("type") == "measured":
-				intensityMeasuredLatest(w, r)
-			case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") == "":
-				intensityReportedLatest(w, r)
-			case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") != "":
-				intensityReported(w, r)
-			default:
-				web.BadRequest(w, r, "service not found.")
-			}
-		case r.URL.Path == "/felt/report":
-			felt(w, r)
-		case strings.HasPrefix(r.URL.Path, "/region/"):
-			region(w, r)
-		case r.URL.Path == "/region":
-			regions(w, r)
+		case r.URL.Query().Get("intensity") != "":
+			quakes(w, r)
+		case r.URL.Query().Get("regionIntensity") != "":
+			quakesRegion(w, r)
+		case strings.HasPrefix(r.URL.Path, "/quake/"):
+			quake(w, r)
 		default:
-			web.BadRequest(w, r, "service not found.")
+			web.BadRequest(w, r, "Can't find a route for this request. Please refer to /api-docs")
 		}
-	case r.Header.Get("Accept") == web.V1JSON:
-
+	case r.URL.Path == "/intensity" && (accept == web.V1GeoJSON || latest):
+		w.Header().Set("Content-Type", web.V1GeoJSON)
 		switch {
-		case r.URL.Path == "/news/geonet":
-			news(w, r)
+		case r.URL.Query().Get("type") == "measured":
+			intensityMeasuredLatest(w, r)
+		case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") == "":
+			intensityReportedLatest(w, r)
+		case r.URL.Query().Get("type") == "reported" && r.URL.Query().Get("publicID") != "":
+			intensityReported(w, r)
 		default:
-			web.BadRequest(w, r, "service not found.")
+			web.BadRequest(w, r, "Can't find a route for this request. Please refer to /api-docs")
 		}
-	// api-doc queries.
+	case r.URL.Path == "/felt/report" && (accept == web.V1GeoJSON || latest):
+		w.Header().Set("Content-Type", web.V1GeoJSON)
+		felt(w, r)
+	case strings.HasPrefix(r.URL.Path, "/region/") && (accept == web.V1GeoJSON || latest):
+		w.Header().Set("Content-Type", web.V1GeoJSON)
+		region(w, r)
+	case r.URL.Path == "/region" && (accept == web.V1GeoJSON || latest):
+		w.Header().Set("Content-Type", web.V1GeoJSON)
+		regions(w, r)
+	case r.URL.Path == "/news/geonet" && (accept == web.V1JSON || latest):
+		w.Header().Set("Content-Type", web.V1JSON)
+		news(w, r)
 	case strings.HasPrefix(r.URL.Path, apidoc.Path):
 		docs.Serve(w, r)
 	case r.URL.Path == "/soh":
@@ -80,6 +82,6 @@ func router(w http.ResponseWriter, r *http.Request) {
 	case r.URL.Path == "/soh/impact":
 		impactSOH(w, r)
 	default:
-		web.NotAcceptable(w, r, "Can't find a route for Accept header. Please refer to /api-docs")
+		web.BadRequest(w, r, "Can't find a route for this request. Please refer to /api-docs")
 	}
 }

--- a/routes_test.go
+++ b/routes_test.go
@@ -19,7 +19,69 @@ func TestRoutes(t *testing.T) {
 		Surrogate:  web.MaxAge10,
 		Response:   http.StatusOK,
 		Vary:       "Accept",
-		TestAccept: true,
+		TestAccept: false,
+	}
+	r.Add("/quake/2013p407387")
+	r.Add("/felt/report?publicID=2013p407387")
+	r.Add("/quake?regionID=newzealand&regionIntensity=unnoticeable&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=weak&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=light&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=moderate&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=strong&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=severe&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=unnoticeable&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=unnoticeable&number=100&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=unnoticeable&number=500&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=unnoticeable&number=1000&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&regionIntensity=unnoticeable&number=1500&quality=best,caution,good")
+	r.Add("/quake?regionID=aucklandnorthland&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=tongagrirobayofplenty&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=gisborne&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=hawkesbay&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=taranaki&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=wellington&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=nelsonwestcoast&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=canterbury&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=fiordland&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=otagosouthland&regionIntensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=unnoticeable&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=weak&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=light&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=moderate&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=strong&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=severe&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=unnoticeable&number=30&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=unnoticeable&number=100&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=unnoticeable&number=500&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=unnoticeable&number=1000&quality=best,caution,good")
+	r.Add("/quake?regionID=newzealand&intensity=unnoticeable&number=1500&quality=best,caution,good")
+	r.Add("/quake?regionID=aucklandnorthland&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=tongagrirobayofplenty&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=gisborne&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=hawkesbay&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=taranaki&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=wellington&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=nelsonwestcoast&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=canterbury&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=fiordland&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/quake?regionID=otagosouthland&intensity=unnoticeable&number=3&quality=best,caution,good")
+	r.Add("/intensity?type=measured")
+	r.Add("/intensity?type=reported&zoom=5")
+	r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
+
+	r.Test(ts, t)
+
+	// GeoJSON routes without explicit accept should route to latest version
+	r = webtest.Route{
+		Accept:     "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+		Content:    web.V1GeoJSON,
+		Cache:      web.MaxAge10,
+		Surrogate:  web.MaxAge10,
+		Response:   http.StatusOK,
+		Vary:       "Accept",
+		TestAccept: false,
 	}
 	r.Add("/quake/2013p407387")
 	r.Add("/felt/report?publicID=2013p407387")
@@ -81,7 +143,7 @@ func TestRoutes(t *testing.T) {
 		Surrogate:  web.MaxAge86400,
 		Response:   http.StatusOK,
 		Vary:       "Accept",
-		TestAccept: true,
+		TestAccept: false,
 	}
 	r.Add("/region/newzealand")
 	r.Add("/region/aucklandnorthland")
@@ -121,7 +183,7 @@ func TestRoutes(t *testing.T) {
 		Surrogate:  web.MaxAge300,
 		Response:   http.StatusOK,
 		Vary:       "Accept",
-		TestAccept: true,
+		TestAccept: false,
 	}
 	r.Add("/news/geonet")
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -68,8 +68,8 @@ func TestRoutes(t *testing.T) {
 	r.Add("/quake?regionID=fiordland&intensity=unnoticeable&number=3&quality=best,caution,good")
 	r.Add("/quake?regionID=otagosouthland&intensity=unnoticeable&number=3&quality=best,caution,good")
 	r.Add("/intensity?type=measured")
-	r.Add("/intensity?type=reported&zoom=5")
-	r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
+	// r.Add("/intensity?type=reported&zoom=5")
+	// r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
 
 	r.Test(ts, t)
 
@@ -130,8 +130,8 @@ func TestRoutes(t *testing.T) {
 	r.Add("/quake?regionID=fiordland&intensity=unnoticeable&number=3&quality=best,caution,good")
 	r.Add("/quake?regionID=otagosouthland&intensity=unnoticeable&number=3&quality=best,caution,good")
 	r.Add("/intensity?type=measured")
-	r.Add("/intensity?type=reported&zoom=5")
-	r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
+	// r.Add("/intensity?type=reported&zoom=5")
+	// r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
 
 	r.Test(ts, t)
 
@@ -248,8 +248,8 @@ func TestGeoJSON(t *testing.T) {
 	r.Add("/region?type=quake")
 	r.Add("/felt/report?publicID=2013p407387")
 	r.Add("/intensity?type=measured")
-	r.Add("/intensity?type=reported&zoom=5")
-	r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
+	// r.Add("/intensity?type=reported&zoom=5")
+	// r.Add("/intensity?type=reported&zoom=5&publicID=2012p673624")
 
 	r.GeoJSON(ts, t)
 }


### PR DESCRIPTION
This is probably as much FYI as needing review .  The upshot being the accept header versioning is now optional.  Requests without an explicit accept header route to the latest api version so both these get the same thing:

curl -v "http://localhost:8080/quake/2013p407387"
curl -v -H "Accept: application/vnd.geo+json;version=1"  "http://localhost:8080/quake/2013p407387"

Which makes exploring using a browser easier and JSONP possible.

Also adds the docs in for measured intensity.

@junghao @bpeng may be interested in this as well.